### PR TITLE
hotfix for games-show populating in reverse

### DIFF
--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -9,6 +9,13 @@ class PiecesController < ApplicationController
 
     redirect_to game_path(1, chosen_num: params[:id]) # replace num with game id; replace query with above
   end 
+
   def edit
+
   end 
+
+  def update
+    
+  end 
+  
 end

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,11 +1,11 @@
 <table class="chessboard">
-    <% (0..7).each do |row_index| %>
+    <% (0..7).reverse_each do |row_index| %>
         <tr class="chessboard">
         <% (0..7).each do |column_index| %>
             <td class="chessboard">
                 <% @game.pieces.each do |piece| %>
                     <% if piece.x_position == column_index && piece.y_position == row_index %>
-                        <%= piece.piece_type.html_safe  %>
+                        <%= "#{piece.x_position},#{piece.y_position}"  %>
                     <% end %>
                 <% end %>
             </td>

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -11,9 +11,6 @@ RSpec.describe Pawn, type: :model do
     Game.skip_callback(:create, :after, :populate_game!, raise: false)
     game = FactoryBot.create(:game)
     @black_pawn = FactoryBot.create(:pawn, x_position: '3', y_position: '6', color: 2, game_id: game.id)
-    puts "hello"
-    puts @black_pawn.move_two?(3,4)
-    puts @black_pawn.isObstructed?(3,4)
     expect(@black_pawn.valid_move?(3,4)).to eq true
   end
 


### PR DESCRIPTION
- removed unneeded lines from pawn spec.
- added piece update method for draggable pieces later on
- fixed reverse populating board